### PR TITLE
Upgrade Magick.NET.Core and Magick.NET-Q16-AnyCPU from 14.12.0 to 14.13.1

### DIFF
--- a/InkyCal.Server/InkyCal.Server.csproj
+++ b/InkyCal.Server/InkyCal.Server.csproj
@@ -26,7 +26,7 @@
 	<PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
 	<PackageReference Include="Bugsnag.AspNet.Core" Version="4.1.0" />
 	<PackageReference Include="Humanizer" Version="3.0.10" />
-	<PackageReference Include="Magick.NET.Core" Version="14.12.0" />
+	<PackageReference Include="Magick.NET.Core" Version="14.13.1" />
 	<PackageReference Include="Markdig.Signed" Version="1.1.2" />
 	<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.6" />
 	<PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.6" />

--- a/InkyCal.Utils.Tests/InkyCal.Utils.Tests.csproj
+++ b/InkyCal.Utils.Tests/InkyCal.Utils.Tests.csproj
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Magick.NET.Core" Version="14.12.0" />
+		<PackageReference Include="Magick.NET.Core" Version="14.13.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/InkyCal.Utils/InkyCal.Utils.csproj
+++ b/InkyCal.Utils/InkyCal.Utils.csproj
@@ -31,8 +31,8 @@
 	<PackageReference Include="Google.Apis.Calendar.v3" Version="1.73.0.4073" />
 	<PackageReference Include="Google.Apis.Oauth2.v2" Version="1.68.0.1869" />
 	<PackageReference Include="Ical.Net" Version="5.2.1" />
-	<PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.12.0" />
-	<PackageReference Include="Magick.NET.Core" Version="14.12.0" />
+	<PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.13.1" />
+	<PackageReference Include="Magick.NET.Core" Version="14.13.1" />
 	<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.202">
 	  <PrivateAssets>all</PrivateAssets>
 	  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Upgrades the Magick.NET libraries across all projects from **14.12.0** to **14.13.1**.

## Changes

| Package | Before | After |
|---|---|---|
| `Magick.NET-Q16-AnyCPU` | 14.12.0 | 14.13.1 |
| `Magick.NET.Core` | 14.12.0 | 14.13.1 |

## Projects updated

- `InkyCal.Utils` – primary consumer (PDF rendering via `MagickImageCollection`)
- `InkyCal.Server` – references `Magick.NET.Core`
- `InkyCal.Utils.Tests` – test project

https://claude.ai/code/session_01XPgeTGkSb6sTapvL48ssGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPgeTGkSb6sTapvL48ssGW)_